### PR TITLE
Add AGENTS.md as published agent guide; add CLAUDE.md for contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,12 +44,13 @@ next-env.d.ts
 .code-review-graph/
 .code-review-graphignore
 
-# IDE and AI tool configs
+# IDE and AI tool configs (personal — not project artifacts)
 .claude/
 .cursor/
 .cursorrules
 .windsurfrules
 .mcp.json
-AGENTS.md
-CLAUDE.md
 GEMINI.md
+# Note: AGENTS.md and CLAUDE.md ARE tracked in this repo.
+# AGENTS.md ships in the npm tarball as the consumer-facing agent guide.
+# CLAUDE.md is the contributor dev guide.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,126 @@
+# AGENTS.md — `@codapet/design-system`
+
+Guidance for AI coding agents working in **consumer codebases** that import `@codapet/design-system`. Read this before reaching for shadcn docs or muscle memory — most things are the same, but a handful of defaults and APIs are not, and the install/publish model is different.
+
+> This file is published with the npm package. Consumer repos pull it into agent context via `@./node_modules/@codapet/design-system/AGENTS.md` in their own `CLAUDE.md` / `AGENTS.md`. Don't edit it in a consumer repo — fixes belong upstream in the design-system repo.
+
+## Mental model
+
+This is a **shadcn/ui-style** library (Radix primitives + cva variants + Tailwind), but it ships as a **single published npm package** — not copy-paste components. So:
+
+- ✅ `import { Button } from '@codapet/design-system'`
+- ❌ Don't `npx shadcn add ...`. Don't copy components into the consumer repo. Add new variants by extending via `className` or, if missing, propose them upstream.
+- ✅ Most shadcn examples translate 1:1 — same `data-slot` attrs, same compound-component patterns (`Card` / `CardHeader` / `CardContent`, `Dialog.Trigger` / `Dialog.Content`, etc.).
+- 'use client' is **already baked in** to every export by the build — never wrap design-system components in your own `'use client'` boundary just for that reason. RSCs that pass props down still work.
+- ESM-only. If a consumer uses Jest, add the package to `transformIgnorePatterns` (or use Vitest, which handles it).
+- Single entry: `from '@codapet/design-system'`. There are **no subpath component imports** — only `'@codapet/design-system'` and `'@codapet/design-system/styles'` exist.
+
+## Required setup in a consumer (Tailwind v4)
+
+In the app's global CSS:
+
+```css
+@import 'tailwindcss';
+@source "../node_modules/@codapet/design-system/dist/**/*.{js,mjs,ts,tsx}";
+@import '@codapet/design-system/styles';
+```
+
+The `@source` line is **mandatory** — without it Tailwind won't see the class names used inside the package and components render unstyled. Tailwind v3 consumers add the same path under `content` in `tailwind.config.js`.
+
+Wrap the app in `<ThemeProvider>` (re-export of `next-themes` with `attribute="class"`, `defaultTheme="light"`, `enableSystem`, `disableTransitionOnChange` pre-set), and mount `<Toaster />` once at the root. Both come from the package.
+
+Required font CSS variables (set on `<body>` or `<html>`): `--font-plus-jakarta-sans` (sans), `--font-noto-serif` (serif, used by display headings — italic), `--font-geist-mono`. Without these, `font-sans`/`font-serif`/`font-mono` fall back to the browser default.
+
+## Differences from shadcn defaults
+
+These are the foot-guns. Knowing them prevents most "why does my Button look wrong" loops.
+
+### Button
+
+- **Default `variant` is `primary`**, not `default`. There is no `default` variant. Available: `primary | secondary | tertiary | outline | ghost | ghost-secondary | ghost-destructive | link | destructive | destructive-secondary | destructive-tertiary`.
+- **Default `size` is `lg` (h-12)**, not `default` (h-9). Sizes: `sm` (h-9) · `md` (h-10) · `lg` (h-12) · `icon` (size-8). For a typical inline action, you usually want `size="md"` — passing nothing gives you a chunky button.
+- Has `cursor-pointer` baked in (shadcn doesn't).
+
+### Input
+
+- Custom `size` prop: `sm` (h-10) · `md` (h-12, default) · `lg` (h-14). All bigger than shadcn's h-9.
+- Built-in `leftIcon`, `rightIcon`, `rightIconOnClick`, `error` props — don't wrap Input in your own icon container, use these. `rightIcon` renders inside a `Button` (clickable); `leftIcon` is decorative.
+- Pass `error={true}` to switch to the error color scheme; it also sets `aria-invalid`.
+
+### Textarea
+
+- Same `error` prop pattern as Input.
+- For auto-grow, use `AutoResizeTextarea` (custom, takes `minHeight` / `maxHeight` in px) — don't reach for `field-sizing-content` manually.
+
+### Toast
+
+- Import `toast` and `Toaster` from `@codapet/design-system`, **not** from `'sonner'`. The exported `Toaster` is pre-styled to match alert tokens; using sonner directly will produce off-brand toasts.
+- Mount `<Toaster />` once in the root layout.
+
+### Form
+
+- Standard shadcn pattern: `react-hook-form` + `zod` + `Form / FormField / FormItem / FormLabel / FormControl / FormMessage`. Same API as shadcn — no surprises here.
+
+### Dialog vs SmartDialog
+
+- `Dialog`/`Drawer` are the standard Radix/Vaul primitives.
+- **`SmartDialog*`** is a CodaPet addition: same API surface, but renders `Drawer` on `≤600px` and `Dialog` above. Prefer it for any modal that should bottom-sheet on mobile. Replace every `Dialog` token with `SmartDialog` (`SmartDialogTrigger`, `SmartDialogContent`, etc.).
+
+## Components added on top of shadcn
+
+These don't exist in shadcn — reach for them instead of building your own:
+
+| Component | Use when |
+|---|---|
+| `AlertBanner` | Inline page-level alerts with `type` = `informative` / `error` / `success`, optional `heading`, `icon`, `dismissible`. Distinct from `Alert` (shadcn-equivalent). |
+| `BadgeActionable` | Clickable chip/filter badge with `selected` state and `onBackground` modifier. |
+| `BadgeInformative` (+ `Group` / `Item`) | Read-only info badge with `colorScheme` = `gray` / `blue` / `yellow`. Use `Group` + `Item` for multi-content badges in one container. |
+| `BadgeNumber` | Numeric pill (counts, step indicators). `state` = `active` / `disabled` / `resting`. |
+| `OptionCard` | Selectable card with built-in radio/checkbox indicator. `selectionType` = `single` / `multiple`, `selectorPosition` = `left` / `right`. Visual-only — wire `selected` and `onClick` yourself. |
+| `DropdownSelect` | Compound `DropdownSelect` / `Trigger` / `Content` / `Option` / `Label`. Lighter alternative to `Select` for simple lists. |
+| `SearchableSelect` | Combobox-style select with search; supports `mode="single"` or `"multiple"` + `maxCount` for tag overflow. |
+| `MultiSelectFreeText` | Tag input where users can type free text **and** pick from suggestions. |
+| `SearchInput` | Search field with `variant="icon"` or `"button"`, suggestions dropdown, and clear button. Don't compose this from `Input` + a Search icon. |
+| `DateInput` / `DateRangeInput` | Text input + Calendar popover. Controlled via `date`/`setDate` (or `dateRange`/`setDateRange`). Configurable `dateFormat` (15 options including `'MMM D, YYYY'`, `'DD/MM/YYYY'`, etc.). Prefer over a bare `Calendar`. |
+| `TimeInput` | Time picker with `timeFormat` = `'12h' \| '24h' \| 'h:mm a' \| 'h:mm A'`. Value is `{ hours, minutes }`, not a `Date`. |
+| `AutoResizeTextarea` | Textarea that grows with content; `maxHeight` enables scroll. Handles RHF `setValue`/`reset` correctly. |
+| `ProgressBar` | Step-based bar; pass `currentStep` + `totalSteps`, or `value` (0–100) directly. |
+| `SmartDialog*` | Responsive Dialog↔Drawer (see above). |
+| `Typography`: `DisplayHeading`, `HeadingXL` … `HeadingXXS` (+ `*Medium` variants), `Body` | Use these instead of raw `<h1>`/`<p>` to inherit the right tokens (`font-serif italic` for display, `text-vibrant-text-heading` for headings, `text-vibrant-text-body` for body). Sizes are responsive (md: breakpoint baked in). |
+| `ThemeToggle` | Drop-in light/dark toggle. |
+
+## Color tokens (don't reach for raw Tailwind colors)
+
+The brand palette lives in CSS variables exposed as Tailwind colors. Use these, not `bg-blue-600`, `text-gray-500`, `border-red-300`, etc. — raw colors won't dark-mode correctly.
+
+- **Brand**: `brand-{subtle,light,normal,vibrant,dark}`, `brand-text-vibrant`. `primary` aliases `brand-normal`.
+- **Surfaces** (backgrounds): `gray-surface-{light,default,dark}`, `primary-surface-{subtle,light,default}`, `secondary-surface-default`, `sand-{subtle,light,normal,dark}`, `sage-{light,normal,dark}`, `rose-{light,normal,dark}`, `error-surface-{subtle,light,default,dark}`, `success-surface-{subtle,default}`, `warning-surface-{subtle,light}`.
+- **Strokes** (borders): `gray-stroke-{light,default}`, `primary-stroke-default`, `secondary-stroke-{light,default}`, `error-stroke-{light,default}`, `success-stroke-light`, `warning-stroke-{default,dark}`, `sand-stroke-disabled`.
+- **Text**: `vibrant-text-{display,heading,body,details,white-darker}`, `secondary-text-dark`, `gray-subtle`, `foreground-secondary`, `destructive-text`.
+- **Icons**: `gray-icon-{subtle,light,default,dark}`, `icon-disabled`.
+- **Semantic** (inherited from shadcn): `background`, `foreground`, `border`, `input`, `ring`, `card`, `popover`, `primary`, `secondary`, `muted`, `accent`, `destructive`, `sidebar*`. These are wired to the brand palette in light **and** dark mode.
+
+Source of truth: `src/styles.css` in this package. If a token is missing, propose it there rather than hardcoding a hex.
+
+## Spacing & sizing conventions
+
+- Components are built with **fixed pixel heights**, not `py-*` shorthands. Buttons: 36/40/48 (sm/md/lg). Inputs: 40/48/56. Badges (informative/actionable): 24/32/40. Match these when building adjacent custom UI.
+- Border radius is **per-component**, not global — Buttons `rounded-md`, Cards `rounded-xl`, Badges `rounded-md` (default) or `rounded-[8px]` (informative/actionable), Alert banners `rounded-[12px]`. Don't override unless you have a reason.
+- Mobile breakpoint is **768px** (`useIsMobile`), but `SmartDialog*` switches at **600px** via its own `useMediaQuery`. They are intentionally different — use the right one.
+
+## Utilities & hooks
+
+- `cn(...inputs)` — `clsx` + `tailwind-merge`. Use it when composing `className` props passed to design-system components, so caller classes win conflicts cleanly.
+- `useIsMobile()` — boolean, 768px breakpoint, SSR-safe (returns `false` on first render).
+- `useTheme()` — re-exported from `next-themes`.
+- `buttonVariants`, `badgeVariants`, etc. — exported `cva` instances. Use them when you need the same look on a non-button element (e.g. an `<a>` styled like a button) instead of reimplementing the styles.
+
+## Common gotchas
+
+- **Unstyled components** → missing `@source` glob for `node_modules/@codapet/design-system/dist/**` in the consumer's CSS.
+- **Wrong default Button look** → you forgot `variant="primary"`/`size="md"` are not the same as shadcn's defaults; passing nothing gives you `primary` + `lg`.
+- **Toast looks generic** → you imported `toast` from `'sonner'` instead of from `@codapet/design-system`.
+- **Modal doesn't bottom-sheet on mobile** → you used `Dialog` instead of `SmartDialog`.
+- **Headings look wrong** → you used a raw `<h1>` instead of `HeadingXL` / `DisplayHeading`. The serif-italic display style only comes from `DisplayHeading`.
+- **Dark mode broken** → you used raw Tailwind colors (`bg-gray-100`, `text-zinc-700`) instead of brand tokens; or you forgot to wrap in `ThemeProvider`.
+- **"Module not found" in tests** → Jest can't parse ESM; add `'@codapet/design-system'` to `transformIgnorePatterns` or switch the test file to Vitest.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+> **Working in a consumer codebase, not this repo?** You want [AGENTS.md](./AGENTS.md) instead — that's the published guide on how to *use* the design system. This file covers how to *develop* it.
+
+## What this repo is
+
+`@codapet/design-system` — a publishable React component library (Shadcn-style, Radix primitives, Tailwind v4) consumed by `admin-dashboard`, `mvp-next`, `community`, and others. The same repo also hosts a Next.js 15 docs/demo app that doubles as a manual test harness.
+
+Two trees, both using the `@/*` alias:
+
+- `src/` — the **library** (everything published to npm). Built by tsup; entry is `src/index.ts`.
+- `app/`, `lib/`, `hooks/`, `public/` (repo root) — the **Next.js demo**. Not published.
+
+There are two near-identical `lib/utils.ts` files (`src/lib/utils.ts` and `lib/utils.ts`) — keep `cn` in sync if you change it.
+
+## Common commands
+
+```bash
+npm run dev          # build:css + next dev --turbopack — demo at localhost:3000
+npm run build:lib    # tsup → dist/index.mjs + dist/index.d.mts, then copies styles.css
+npm run build:all    # lib + demo
+npm run lint         # eslint
+npm run test:lib     # smoke test: imports dist/index.mjs and counts exports
+```
+
+**Vitest is configured but there is no `test` script.** Run unit tests directly:
+
+```bash
+npx vitest run                                          # single run
+npx vitest run src/components/ui/date-input.test.tsx    # one file
+```
+
+## Build pipeline (tsup)
+
+Configured in `tsup.config.ts`:
+
+- ESM only. No CJS.
+- Every output gets a `"use client";` banner injected. Don't add `'use client'` manually inside source.
+- All runtime deps are `external`. **If you add a new runtime dependency, add it to both `dependencies` in `package.json` AND the `external` array in `tsup.config.ts`** — otherwise it gets bundled.
+- `dts: true` emits types from `tsconfig.lib.json`, which is **stricter than `tsconfig.json`** (`noUnusedLocals`, `noUnusedParameters`, `verbatimModuleSyntax`). The demo's `tsc` can pass while `build:lib` fails — always run `build:lib` before publishing.
+- `src/styles.css` is **copied, not processed** (`build:css` does `cp src/styles.css dist/styles.css`). Edit tokens in `src/styles.css`. Restart `npm run dev` after changes.
+
+## Adding a new component
+
+1. Create `src/components/ui/<name>.tsx`. Don't add `'use client'` (banner adds it).
+2. Re-export from `src/index.ts`. Missing this is the most common reason consumers can't find a new component.
+3. New third-party dep? Add to `dependencies` *and* `external` in `tsup.config.ts`.
+4. Add a demo route under `app/(docs)/<id>/page.tsx` and a nav entry in `app/(docs)/layout.tsx`.
+5. Run `npm run build:lib` to confirm `tsconfig.lib.json` passes.
+6. **If the new component changes consumer-facing API or defaults, update [AGENTS.md](./AGENTS.md).**
+
+## Releasing
+
+Tags `v*.*.*` trigger `.github/workflows/release.yml`, which runs `build:lib`, `build:css`, `test:lib`, then `npm publish --access public` (requires `NPM_TOKEN`). `prepublishOnly` runs the same checks locally.
+
+```bash
+# bump version in package.json
+git commit -am "chore(release): vX.Y.Z"
+git tag vX.Y.Z
+git push --follow-tags
+```
+
+The `files` field in `package.json` controls what ships. Currently: `dist/**` and `AGENTS.md`. Add anything else explicitly.
+
+## Conventions
+
+- Prettier: no semicolons, single quotes, no trailing commas, 2-space, `arrowParens: 'avoid'`.
+- Path alias `@/*` → `./src/*` for library code.
+- Shadcn "new-york" style. Icons from `lucide-react`.
+- `cn(...)` from `src/lib/utils.ts` for class merging.
+- Brand tokens live in `src/styles.css` under `@theme inline`. Prefer `brand-*` / `sand-*` / `vibrant-text-*` / `*-surface-*` / `*-stroke-*` over raw Tailwind colors so dark mode works.
+
+## code-review-graph MCP
+
+Per `.kiro/steering/`, this project has a code knowledge graph. When exploring or reviewing, prefer `semantic_search_nodes`, `query_graph`, `detect_changes`, `get_review_context`, `get_impact_radius` over Grep/Glob — faster, and they surface caller/dependent/test relationships. Fall back to Read/Grep only when the graph doesn't cover what you need.

--- a/README.md
+++ b/README.md
@@ -349,6 +349,20 @@ For detailed information about how dependencies are organized and managed, see [
 - **Dependencies**: UI libraries and utilities (bundled with library)
 - **Dev Dependencies**: Build tools and development utilities (not included in package)
 
+## Using with AI coding agents
+
+This package ships an [`AGENTS.md`](./AGENTS.md) at its root — a guide for AI agents (Claude Code, Cursor, Codex, etc.) explaining how the library differs from stock shadcn/ui (button defaults, custom components, brand tokens, common gotchas). It's published with the npm tarball, so once you've installed the package, the file is at `node_modules/@codapet/design-system/AGENTS.md`.
+
+To make Claude Code automatically pull it into every session in your consumer repo, add one line to your repo's `CLAUDE.md` (or `AGENTS.md`):
+
+```
+@./node_modules/@codapet/design-system/AGENTS.md
+```
+
+The `@path` syntax inlines the file's content into the agent's context. Because it resolves at session start, the guide always matches the version of `@codapet/design-system` you have installed — bump the dep, get the updated guide, no copy-paste.
+
+For other agent tools (Cursor, Codex, etc.) the file is still readable at the same path; refer to your tool's docs for how to point it at additional context files.
+
 ## Contributing
 
 1. Fork the repository

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "./dist/styles.css"
   ],
   "files": [
-    "dist/**"
+    "dist/**",
+    "AGENTS.md"
   ],
   "scripts": {
     "dev": "npm run build:css && next dev --turbopack",


### PR DESCRIPTION
## Summary

Adds two agent-facing documentation files with distinct audiences and ships the consumer-facing one with the npm package.

- **`AGENTS.md`** — guide for AI agents working in **consumer** codebases (`admin-dashboard`, `mvp-next`, `community`, etc.). Focuses on how this library differs from stock shadcn/ui: `Button`/`Input` default variants and sizes, custom components added on top (`AlertBanner`, `OptionCard`, `SmartDialog*`, `DateInput`, the Typography family, …), brand color tokens, dark-mode rules, and common gotchas (raw Tailwind colors, missing `@source` glob, importing `toast` from `'sonner'` instead of from this package, etc.). Added to the `"files"` array in `package.json` so it ships in the npm tarball. After publish, every consumer's installed copy at `node_modules/@codapet/design-system/AGENTS.md` is pinned to the version of the library they have installed.

- **`CLAUDE.md`** — contributor dev guide for *this* repo. Covers the dual lib+demo layout, `tsup` build pipeline quirks (auto-injected `'use client'` banner, externalized deps, stricter `tsconfig.lib.json`), the new-component checklist, and the release flow.

- **`README.md`** — new "Using with AI coding agents" section explaining the one-line `@./node_modules/@codapet/design-system/AGENTS.md` import wiring that consumer repos add to their own `CLAUDE.md` to pull the guide into Claude Code context automatically. The `@path` syntax means the guide always matches the installed version — no copy-paste, no drift.

- **`.gitignore`** — removes the blanket `AGENTS.md` / `CLAUDE.md` exclusion. Both files are now tracked project artifacts. Other personal AI configs (`.claude/`, `.cursor/`, `GEMINI.md`, …) remain ignored.

## Why

Consumer repos kept rediscovering the same library quirks every session — Button defaults, the brand token system, custom components like `SmartDialog`, the `Toaster` import path. Putting the answers in a versioned, published doc means each consumer always sees guidance that matches the library version they have installed.

## Reviewer notes

- **Activation requires a release.** The currently-published v0.7.3 doesn't include `AGENTS.md`, so the `@import` lines added to consumer-repo `CLAUDE.md` files in this workspace are no-ops until a version with this commit is published and consumers `npm install`. Suggest cutting v0.7.4 (or v0.8.0) right after merge.
- **Out-of-PR companion edits already made locally** (not part of this PR — they live in different repos): added the `@./node_modules/@codapet/design-system/AGENTS.md` import line to `CLAUDE.md` in `admin-dashboard`, `mvp-next`, and `community`. `booking-engine-refactor` and `super-flow` were skipped — they don't depend on this package per their `package.json`. Each consumer-repo edit will need its own PR.
- **`.gitignore` policy shift** — the previous policy treated AI agent files as personal/local. For a library used across many codebases, AGENTS.md needs to be a versioned project artifact instead. Open to keeping CLAUDE.md ignored if you'd rather not commit a contributor-only file; happy to drop it from this PR.

## Test plan

- [ ] `npm run build:lib && npm pack` locally; inspect tarball with `tar tzf` and confirm `AGENTS.md` is present at the package root.
- [ ] Install the local tarball into a consumer repo (e.g. `admin-dashboard`); confirm `node_modules/@codapet/design-system/AGENTS.md` exists.
- [ ] Open Claude Code in that consumer repo; confirm the `@import` resolves and the AGENTS.md content appears in the loaded context.
- [ ] Publish a patch release after merge so the wiring activates for consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)